### PR TITLE
adding logic to register page to have a password length minimum.

### DIFF
--- a/SFAMarketplaceWEB/Pages/Account/Register.cshtml.cs
+++ b/SFAMarketplaceWEB/Pages/Account/Register.cshtml.cs
@@ -14,6 +14,12 @@ namespace SFAMarketplaceWEB.Pages.Account
 
         public ActionResult OnPost()
         {
+            if (NewUser.Password != null && NewUser.Password.Length < 10)
+            {
+                ModelState.AddModelError("RegisterError", "Password must be at least 10 characters");
+                return Page();
+            }
+
             if (ModelState.IsValid)
             {
                 if (UsernameDoesNotExist(NewUser.Username) && EmailDoesNotExist(NewUser.Email))


### PR DESCRIPTION
I added an if statement to the register.cshtml.cs page that checks if the users password is at least 10 characters long, if its shorter than 10 characters then they get the error.